### PR TITLE
Fix #88

### DIFF
--- a/src/datatypes/Sequence.jl
+++ b/src/datatypes/Sequence.jl
@@ -413,11 +413,10 @@ get_kspace(seq::Sequence; Δt=1) = begin
 	kspace = γ * k #[m^-1]
 	#Interp, as Gradients are piece-wise linear, the integral is piece-wise quadratic
 	#Nevertheless, the integral is sampled at the ADC times so a linear interp is sufficient
-	ts = t .+ Δt
 	t_adc =  get_sample_times(seq)
-	kx_adc = LinearInterpolation(ts,kspace[:,1])(t_adc)
-	ky_adc = LinearInterpolation(ts,kspace[:,2])(t_adc)
-	kz_adc = LinearInterpolation(ts,kspace[:,3])(t_adc)
+	kx_adc = LinearInterpolation(t,kspace[:,1],extrapolation_bc=0)(t_adc)
+	ky_adc = LinearInterpolation(t,kspace[:,2],extrapolation_bc=0)(t_adc)
+	kz_adc = LinearInterpolation(t,kspace[:,3],extrapolation_bc=0)(t_adc)
 	kspace_adc = [kx_adc ky_adc kz_adc]
 	#Final
 	kspace, kspace_adc

--- a/src/simulation/SimulatorCore.jl
+++ b/src/simulation/SimulatorCore.jl
@@ -197,7 +197,7 @@ function run_sim_time_iter(obj::Phantom,seq::Sequence, t::Array{Float64,1}, Δt;
 	end
 	#Output
 	t_interp = get_sample_times(seq) 
-	S_interp = LinearInterpolation(t.+Δt,S,extrapolation_bc=0)(t_interp) .* get_sample_phase_compensation(seq)
+	S_interp = LinearInterpolation(t,S,extrapolation_bc=0)(t_interp) .* get_sample_phase_compensation(seq)
 	(S_interp, M0)
 end
 


### PR DESCRIPTION
This is also related the the closed issue #44.
The dt variable was deleted since is unnecessary for the time vector