### PR TITLE
Fix for no-gpu devices

### DIFF
--- a/KomaMRICore/src/simulation/GPUFunctions.jl
+++ b/KomaMRICore/src/simulation/GPUFunctions.jl
@@ -9,15 +9,15 @@ const use_cuda = Ref{Union{Nothing,Bool}}(nothing)
 Simple function to print the CUDA devices available in the host.
 """
 print_gpus() = begin
-    @info "Loading GPUs"
-    if has_cuda()
+    check_use_cuda()
+    if use_cuda[]
 	    println( "$(length(devices())) CUDA capable device(s)." )
 	    for (i,d) = enumerate(devices())
 	    	u = i == 1 ? "*" : " "
 	    	println( "  ($(i-1)$u) $(name(d))")
 	    end
     else
-        println("No GPUs Found")
+        println("0 CUDA capable devices(s).")
     end
 end
 

--- a/KomaMRICore/src/simulation/GPUFunctions.jl
+++ b/KomaMRICore/src/simulation/GPUFunctions.jl
@@ -9,11 +9,16 @@ const use_cuda = Ref{Union{Nothing,Bool}}(nothing)
 Simple function to print the CUDA devices available in the host.
 """
 print_gpus() = begin
-	println( "$(length(devices())) CUDA capable device(s)." )
-	for (i,d) = enumerate(devices())
-		u = i == 1 ? "*" : " "
-		println( "  ($(i-1)$u) $(name(d))")
-	end
+    @info "Loading GPUs"
+    if has_cuda()
+	    println( "$(length(devices())) CUDA capable device(s)." )
+	    for (i,d) = enumerate(devices())
+	    	u = i == 1 ? "*" : " "
+	    	println( "  ($(i-1)$u) $(name(d))")
+	    end
+    else
+        println("No GPUs Found")
+    end
 end
 
 """
@@ -26,7 +31,7 @@ function check_use_cuda()
 		@warn "CUDA.jl found cuda, but did not find libcudnn. Some functionality will not be available."
 		end
 		if !(use_cuda[])
-		@info """The GPU function is being called but the GPU is not accessible. 
+		@info """The GPU function is being called but the GPU is not accessible.
 					Defaulting back to the CPU. (No action is required if you want to run on the CPU).""" maxlog=1
 		end
 	end

--- a/src/KomaUI.jl
+++ b/src/KomaUI.jl
@@ -113,7 +113,6 @@ global recParams = merge(default, rec)
 default = Dict{String,Any}()
 global simParams = merge(default, sim)
 #GPUs
-@info "Loading GPUs"
 KomaMRICore.print_gpus()
 #OBERSVABLES
 global seq_obs = Observable{Sequence}(seq)

--- a/src/KomaUI.jl
+++ b/src/KomaUI.jl
@@ -113,6 +113,7 @@ global recParams = merge(default, rec)
 default = Dict{String,Any}()
 global simParams = merge(default, sim)
 #GPUs
+@info "Loading GPUs"
 KomaMRICore.print_gpus()
 #OBERSVABLES
 global seq_obs = Observable{Sequence}(seq)


### PR DESCRIPTION
The program didn't work properly for computers with no GPU (it was an small part of code when printing the available GPU devices). This commit solves the problem.