### PR TITLE
Added workaround to use KomaMRI in Julia 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ To install just write the following in the Julia REPL:
 ```julia
 ] add KomaMRI
 ```
+
+**IMPORTANT!!!** After Julia 1.9 release, some features don't work properly when using multithreading with the user interface. By the time being, the following workaround is necessary to solve some errors:
+```julia
+] add WebIO#a18e830a5a4d1193472e2a111ca4a62c1165f716
+```
+
 ## First run
 KomaMRI.jl comes with a handy GUI that contains a brain phantom with an EPI sequence. To open it use:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To install just write the following in the Julia REPL:
 ] add KomaMRI
 ```
 
-**IMPORTANT!!!** After Julia 1.9 release, some features don't work properly when using multithreading with the user interface. By the time being, the following workaround is necessary to solve some errors:
+**IMPORTANT!!!** In Julia 1.9 and KomaMRI v0.7.3, some UI features don't work properly when using Julia with multiple threads (by starting it with `julia -t auto` or `julia -t Nthreads`). This is currently being fixed. For the time being, we recommend installing a dev version of WebIO.jl that fixes these problems. This can be done by doing the following:
 ```julia
 ] add WebIO#a18e830a5a4d1193472e2a111ca4a62c1165f716
 ```

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -13,6 +13,12 @@ julia> ]
 
 (@v1.8) pkg> add KomaMRI
 ```
+
+**IMPORTANT!!!** After Julia 1.9 release, some features don't work properly when using multithreading with the user interface. By the time being, the following workaround is necessary to solve some errors:
+```julia
+(@v1.9) pkg> add WebIO#a18e830a5a4d1193472e2a111ca4a62c1165f716
+```
+
 Then press `Ctrl+C` or `backspace` to return to the `julia>` prompt.
 
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -11,10 +11,10 @@ Once Julia is installed, open the Julia REPL and add the `KomaMRI` package. To b
 ```julia-repl
 julia> ]
 
-(@v1.8) pkg> add KomaMRI
+(@v1.9) pkg> add KomaMRI
 ```
 
-**IMPORTANT!!!** After Julia 1.9 release, some features don't work properly when using multithreading with the user interface. By the time being, the following workaround is necessary to solve some errors:
+**IMPORTANT!!!** In Julia 1.9 and KomaMRI v0.7.3, some UI features don't work properly when using Julia with multiple threads (by starting it with `julia -t auto` or `julia -t Nthreads`). This is currently being fixed. For the time being, we recommend installing a dev version of WebIO.jl that fixes these problems. This can be done by doing the following:
 ```julia
 (@v1.9) pkg> add WebIO#a18e830a5a4d1193472e2a111ca4a62c1165f716
 ```


### PR DESCRIPTION
I added an important note in the readme and in the docs to use KomaMRI in Julia 1.9.